### PR TITLE
Laravel 11 compatibility 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   },
   "require": {
-    "symfony/http-foundation": "^6.1",
+    "symfony/http-foundation": "^7.0",
     "league/flysystem": "^3.0",
     "league/flysystem-ziparchive": "^3.2",
     "league/flysystem-read-only": "^3.3"


### PR DESCRIPTION
As part of the Laravel 11 upgrade, `symfony/http-foundation` needs to be updated to version 7. I didn't find tests for this package and performed a manual test on my project, which seems to work fine (please see the screenshot).

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/c285ef35-e9a3-484e-a62e-ec199bce4bbc">

@n1crack I didn't find a `dev` branch for this package. I highly recommend having a new dev branch for such PRs. Moreover, you probably want to update the version so that Laravel 10 still works with `http-foundation` version 6.